### PR TITLE
Fixed a quote mark on icon link

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -13,7 +13,7 @@
       <meta name="viewport" content="width=device-width, initial-scale=1">
       {% include 'partials/metadata.html.twig' %}
         {% set image_parts = pathinfo(grav.theme.config.theme.favicon) %}
-        <link rel="icon" type="image/png" href="{{ url('theme://assets') }}/{{ image_parts.basename }}”/>
+        <link rel="icon" type="image/png" href="{{ url('theme://assets') }}/{{ image_parts.basename }}"/>
 
 
       <link rel="canonical" href="{{ page.url(true, true) }}"/>


### PR DESCRIPTION
Line 16 contains a ” quote instead of a " quote, very similar but this caused issues where the icon for the tab would never appear and it also ruined some of line 18 as well which my browser thought was contained within the quote marks.

This might seem like a small thing but I hope this request is small enough to be integrated into the main branch