### PR TITLE
Changed favicon location

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -49,7 +49,7 @@ form:
         - .jpeg
     theme.favicon:
       type: filepicker
-      folder: 'theme@:/images'
+      folder: 'theme@:/assets'
       label: Theme Favicon
       preview_images: true
       accept:


### PR DESCRIPTION
The favicon cannot be changed from the default included logo without uploading files directly to the theme folder outside the Admin Panel UI

This changes that so that the favicon can be picked from the file unloader that is present on the options page

Another small change but it seems extremely strange that the favicon cannot be directly uploaded though the admin panel like the logo can so this changes that as well